### PR TITLE
Fix Rspec-Subject example to match descriptive text

### DIFF
--- a/RubyOnRails/rspec-style-guide.md
+++ b/RubyOnRails/rspec-style-guide.md
@@ -241,7 +241,7 @@
 
   # good
   describe SomeClass do
-    subject(:some_class) { SomeClass.new }
+    subject(:some_class) { described_class.new }
 
     describe '#some_method' do
       it 'does what we want' do


### PR DESCRIPTION
## Summary
Text says to 'use `described_class`' to instantiate a subject and the example
shows the use of the described class name as the good way to do it.
This PR tries to match example and text.

Also maybe it's good to open the debate of wether "`some_class`" is a *descriptive name*
for an instance of `SomeClass`. 