### PR TITLE
Update README.md

### DIFF
--- a/ruby-on-rails/README.md
+++ b/ruby-on-rails/README.md
@@ -13,7 +13,7 @@ At [Wolox](https://wolox.co), we have developed the [RoR kickoff guide](./docs/k
 - [Async-Requests](https://github.com/Wolox/async-requests)
 - [CodeStats](https://github.com/Wolox/codestats)
 - [CodeStats Metrics Reporter](https://github.com/Wolox/codestats-metrics-reporter)
-- [Argentinian Localities][https://github.com/Wolox/arg-localities]
+- [Argentinian Localities](https://github.com/Wolox/arg-localities)
 
 ## Useful Documentation
 


### PR DESCRIPTION
# Summary
- Fixed a little typo in the rails readme

# Screenshot
Before:
![tech guides ruby on rails at master wolox tech guides](https://cloud.githubusercontent.com/assets/1130309/25761265/9211de1a-31da-11e7-9ad6-d415a76b70dd.png)
Now: 
![tech guides readme md at 43c76d000c4bf50adafd74fa209a8824cc38216d wolox tech guides](https://cloud.githubusercontent.com/assets/1130309/25761302/b02e25d4-31da-11e7-911a-94ec838885dc.png)
