### PR TITLE
Removed nuclide

### DIFF
--- a/react-native/README.md
+++ b/react-native/README.md
@@ -20,15 +20,6 @@ At [Wolox](http://wolox.com.ar), we have developed the [React Native Bootstrap](
 [Atom](https://atom.io/) is a highly customizable text editor. It's open source, developed by GitHub and has tons of Packages to extend its functionality.
 For more information: check [Frontend style-guide](https://github.com/Wolox/tech-guides/blob/master/frontend/docs/style-guide.md#atom)
 
-##### Nuclide
-[Nuclide](https://nuclide.io/) provides a development environment for React Native projects. One of its major benefits is that it lets you debug code directly from Atom.
-
-To install it, run this line in your terminal:
-
-```
-apm install nuclide
-```
-
 ##### React
 React.js (JSX) language support, indentation, snippets, auto completion, reformatting
 


### PR DESCRIPTION
### Summary
Removed nuclide from React packages because it no longer supports debugging

https://github.com/facebook/nuclide/releases/tag/v0.236.0