### PR TITLE
[iOS] Fix kickoff, create the setup branch earlier

### DIFF
--- a/iOS/docs/kickoff/README.md
+++ b/iOS/docs/kickoff/README.md
@@ -60,10 +60,6 @@ Don't forget to add the changes.
 
 Watch the message! This will be your project's first commit ;)
 
-`$ git push origin project-setup -u`
-
-Then send it to the clouds!
-
 #### Project Renaming
 
 Open XCode project by running:
@@ -142,6 +138,10 @@ Add these changes by running:
 
 And commit them:
 `$ git commit -m "Rename project"`
+
+Then send it to the clouds!
+`$ git push origin HEAD -u`
+
 
 ### Configure CI
 

--- a/iOS/docs/kickoff/README.md
+++ b/iOS/docs/kickoff/README.md
@@ -48,6 +48,10 @@ Fast copy everything but the .git file from base project to your project.
 
 Change to your project directory.
 
+`$ git checkout -b "project-setup" `
+
+Create a new branch to properly set up the project.
+
 `$ git add .`
 
 Don't forget to add the changes.
@@ -56,12 +60,9 @@ Don't forget to add the changes.
 
 Watch the message! This will be your project's first commit ;)
 
-`$ git push origin HEAD -u`
+`$ git push origin project-setup -u`
 
 Then send it to the clouds!
-
-When these is done a new branch should be created to properly set up the project. Once again, run on your terminal:
-`$ git checkout -b "project-setup" `
 
 #### Project Renaming
 


### PR DESCRIPTION
The guide was asking the user to push the changes to `master`, a branch that should be (and probably is) protected. I moved the creation of the branch `project-setup` up so the user creates it earlier and is able to push the changes to that branch.