### PR TITLE
[iOS] Add marathon comment to download Alamofire dep

### DIFF
--- a/useful-scripts/scripts/copyTrello.swift
+++ b/useful-scripts/scripts/copyTrello.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Alamofire
+import Alamofire // marathon:https://github.com/Alamofire/Alamofire.git
 
 extension String {
 


### PR DESCRIPTION
This allows marathon CLI to download alamofire without having to add the dependency explicitly via CLI