### PR TITLE
[IT] [iOS] Correcting zsh configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Mac noise
+.DS_Store
+*/.DS_Store

--- a/useful-scripts/scripts/setup-environment-mac.sh
+++ b/useful-scripts/scripts/setup-environment-mac.sh
@@ -50,7 +50,7 @@ function command_exists () {
 function shell_configuration_file () {
   case $SHELL in
     /bin/zsh )
-      echo ~/.zshrc_profile;;
+      echo ~/.zshrc;;
     /bin/bash )
       echo ~/.bash_profile;;
     * )


### PR DESCRIPTION
For zsh the configuration file is ~/.zshrc and not ~/.zshrc_profile, as seen in Diego's newly setup mac.