### PR TITLE
[React] changed old react native link to new react folder in main README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Under every technology folder mentioned [below](#technologies-index), you will f
 
 - [Front-End](./frontend/README.md)
 
-- [React Native](./react-native/README.md)
+- [React & React Native](./react/README.md)
 
 - [Android](./android/README.md)
 


### PR DESCRIPTION
## Summary

Changed broken react-native link in main README.md to new react folder link.