### PR TITLE
[Wolox] Adding templates to repo

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+**Remember** to use the [corresponding tag](../README.md#contributing) in this PR's title.
+
+## Summary
+
+A brief description of the pull request.
+
+
+## Known issues / Notes
+
+You can report errors found or any missing work.
+
+
+## Others ...
+
+You could add any other section you may need, like _Discussion_ for example.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Under every technology folder mentioned [below](#technologies-index), you will f
 - **Useful Documentation**: Good practices, talks, useful guides and highlights.
 - **Posts**: Posts written for the [Wolox Engineering Blog](http://eng.wolox.co) for the given technology.
 
+If you need to add a new technology, follow the [Tech Kickoff Guide](./templates/docs/tech_kickoff.md).
+
 ## Technologies Index
 
 - [Ruby On Rails](./ruby-on-rails/README.md)

--- a/iOS/README.md
+++ b/iOS/README.md
@@ -7,21 +7,22 @@ At [Wolox](http://wolox.com.ar), we have developed the [iOS kickoff guide](./doc
 ## Open Source
 
 - [iOS Base Project](https://github.com/Wolox/ios-base-project)
-- [Wolmo Core iOS](https://github.com/Wolox/wolmo-core-ios)
-- [Wolmo Authentication iOS](https://github.com/Wolox/wolmo-authentication-ios)
 - [Wolox iOS Style Guide](https://github.com/Wolox/ios-style-guide)
+- [Carthage Cache](https://github.com/Wolox/carthage_cache)
+- [Fastlane for mobile](https://github.com/Wolox/fastlane-mobile)
+- [Wolmo Core iOS](https://github.com/Wolox/wolmo-core-ios)
+- [Wolmo Reactive Core iOS](https://github.com/Wolox/wolmo-reactive-core-ios)
+- [Wolmo Authentication iOS](https://github.com/Wolox/wolmo-authentication-ios)
+- [Wolmo Networking iOS](https://github.com/Wolox/wolmo-networking-ios)
 - [WARP](https://github.com/Wolox/warp)
 
 ## Useful Documentation
 
 ### Standards
 
-### Wolox
-
-- [Kickoff guide](./docs/kickoff/README.md)
-- [Style guide](https://github.com/Wolox/ios-style-guide)
 - [App Structure](./docs/app-structure.md)
 - [Mobile conventions naming](../mobile/docs/naming/README.md)
+- [Style guide](https://github.com/Wolox/ios-style-guide)
 
 ### UI
 
@@ -42,6 +43,10 @@ At [Wolox](http://wolox.com.ar), we have developed the [iOS kickoff guide](./doc
 ### Functional Reactive Programming
 
 - [Signal & SignalProducer Responsability Discussion - RAC github](https://github.com/ReactiveCocoa/ReactiveCocoa/pull/2639#issuecomment-170258058)
+
+### scripts
+
+- [iOS Useful Scripts](https://github.com/guidomb/ios-scripts)
 
 ### Talks
 
@@ -66,3 +71,5 @@ At [Wolox](http://wolox.com.ar), we have developed the [iOS kickoff guide](./doc
 - [How to Increase my iOS Application Security](https://medium.com/wolox-driving-innovation/how-to-increase-my-ios-application-security-17681f068d11)
 - [An easier development flow using Javascript and WKWebView on iOS](https://medium.com/wolox-driving-innovation/an-easier-development-flow-using-javascript-and-wkwebview-on-ios-592b5037b53d)
 - [Bluetooth Low Energy on iOS: The Easy Way](https://medium.com/wolox-driving-innovation/bluetooth-low-energy-on-ios-the-easy-way-628d13ff1127)
+- [IOS In-App Purchases and Subscriptions](https://medium.com/wolox-driving-innovation/3b361da0f038)
+- [IOS Deep linking: URL Scheme vs Universal Links](https://medium.com/wolox-driving-innovation/ios-deep-linking-url-scheme-vs-universal-links-50abd3802f97)

--- a/iOS/docs/kickoff/README.md
+++ b/iOS/docs/kickoff/README.md
@@ -3,8 +3,7 @@ iOS Kickoff guide
 
 This is a tutorial explaining how to kickoff an iOS project from scratch. Some steps can't be followed without being granted access to certain services: request them to an iOS' technical leader:
 
-* [Pablo Giorgi](mailto:pablo.giorgi@wolox.com.ar)
-* [Guido Marucci Blas](mailto:guidomb@wolox.com.ar)
+* [Daniela Paula Riesgo](mailto:daniela.riesgo@wolox.com.ar)
 
 ## Before starting...
 
@@ -24,7 +23,7 @@ The following will be needed to start an iOS project kickoff process:
 
 Next steps will get your iOS project configured, for these, replace `Project Name` with your project name.
 
-A little heads up: It's *extremely* important naming conventions, such as camel case notation and so on, are followed. I.e.: if `BaseProject.xcodeproj` should be renamed with our project name, then it should be `ProjectName.xcodeproj`. Always follow the naming pattern on the base project. Read this [Convention guide](../../../mobile/docs/naming/README.md) to figure out what the `Project Name` should be.
+A little heads up: It's *extremely* important naming conventions, such as camel case notation and so on, are followed. I.e.: if `BaseProject.xcodeproj` should be renamed with our project name, then it should be `ProjectName.xcodeproj`. Always follow the naming pattern on the base project. Read this [Convention guide](../../../mobile/docs/naming/README.md) to figure out what the `Project Name` should be. There can't be symbols like `-` in the new project's name or the renaming won't work.
 
 Also, this is meant to be sequentially, so don't skip or mix steps.
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,5 @@
+### Wolox Templates
+
+- [Tech Kickoff in this repo](./new_tech_kickoff.md)
+- [PR template](../git/docs/pull_request_template.md)
+- [Issue template](../git/docs/issue_template.md)

--- a/templates/docs/tech_kickoff.md
+++ b/templates/docs/tech_kickoff.md
@@ -3,8 +3,10 @@
 1. Create a new folder in this repository with the name of the technology.
 2. Create a `README.md` in the folder which must have the sections mentioned [here](../../README.md#repository-structure).
     Remember to add all information that may be useful. That may include: style guides, conventions, standards, architecture used, tutorials or documentation on dependencies, tutorial or documentation on programming languages, scripts or tools for development, among others.
-3. Any other resource document created should be inside a `docs` folder.
-4. Any subsection you may need should have its own `README.md`.
+3. Add tech to [overall README](../../README.md).
+4. Any other resource document created should be inside a `docs` folder.
+5. Any subsection you may need should have its own `README.md`.
+
 
 **Remember** to always keep this information updated, which is why we recommend
 creating the documents inside the repository rather than linking, when it's possible.

--- a/templates/docs/tech_kickoff.md
+++ b/templates/docs/tech_kickoff.md
@@ -1,0 +1,10 @@
+### Tech Kickoff
+
+1. Create a new folder in this repository with the name of the technology.
+2. Create a `README.md` in the folder which must have the sections mentioned [here](../../README.md#repository-structure).
+    Remember to add all information that may be useful. That may include: style guides, conventions, standards, architecture used, tutorials or documentation on dependencies, tutorial or documentation on programming languages, scripts or tools for development, among others.
+3. Any other resource document created should be inside a `docs` folder.
+4. Any subsection you may need should have its own `README.md`.
+
+**Remember** to always keep this information updated, which is why we recommend
+creating the documents inside the repository rather than linking, when it's possible.


### PR DESCRIPTION
Adding templates folder with "tech kickoff".
So that it's easier that we have all techs and projects with same (or similar) structure and standards.
(It's easier to have everyone copy templates from here than from an old project that may have it outdated.