### PR TITLE
[Front-End] Add store.js to folder structure

### DIFF
--- a/react/style-guide.md
+++ b/react/style-guide.md
@@ -64,6 +64,7 @@ src
     | i18n.js
 └───constants
 └───redux
+│   | store.js
 │   └───myReducer
 │       | actions.js
 │       | reducer.js


### PR DESCRIPTION
Add `store.js` to the directory structure. This is mostly to help the trainees place the files in the correct folder.