### PR TITLE
[REACT] Add link at useful documentation to atom extension

### DIFF
--- a/react/README.md
+++ b/react/README.md
@@ -25,5 +25,7 @@
 
 - [VSCode useful extensions](./docs/vscode-extensions.md)
 
+- [Atom useful extensions](https://github.com/Wolox/tech-guides/blob/master/frontend/docs/style-guide.md#atom) 
+
 ## Posts
 - [Introducing redux-recompose](https://medium.com/wolox-driving-innovation/932e746b0198)


### PR DESCRIPTION
**Remember** to use the [corresponding tag](../README.md#contributing) in this PR's title.

## Summary

- I add a link to Atom extensions at react useful documentation section.


