### PR TITLE
[tech-guides]delete ruby on rails layout from frontend page

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -10,8 +10,6 @@
 
 - [Vue](./vue/)
 
-- [Ruby on Rails layout](./ruby-on-rails-layout/)
-
 ## Useful Documentation
 
 ### General

--- a/frontend/ruby-on-rails-layout/README.md
+++ b/frontend/ruby-on-rails-layout/README.md
@@ -1,1 +1,0 @@
-# Ruby on Rails Layout Tech Guides [Tech Guides under construction]


### PR DESCRIPTION
## Summary

- I delete ruby on rails layout from frontend page.

## Screenshots

![selection_204](https://user-images.githubusercontent.com/25588839/54049979-d4b80e80-41bc-11e9-9f38-7a53de0de9ce.png)

## Trello card

https://trello.com/c/Nll1xLmZ/2-sacar-ruby-on-rails-layout-del-tech-guides-de-front
