### PR TITLE
[Tech-guides] Deleted "Generate Mock API" link

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -23,7 +23,6 @@
 - [External Resources](./docs/style-guide.md#external-resources)
 - [Learning Resources - Frontend](./docs/style-guide.md#learning-resources---frontend)
 - [Learning Resources - Design - UI/UX](./docs/style-guide.md#learning-resources---design---uiux)
-- [Generate an API Mock](https://medium.com/@housecor/rapid-development-via-mock-apis-e559087be066#.479nnonvy)
 
 ## Posts
 


### PR DESCRIPTION
## Summary

- Deleted "Generate Mock API" link from `Frontend` main page

## Screenshots 

### Before 

![image](https://user-images.githubusercontent.com/36488701/54218985-5796dd00-44cd-11e9-96b6-44673dcc3e4c.png)

### Now 

![image](https://user-images.githubusercontent.com/36488701/54218955-48179400-44cd-11e9-86ff-4789a1fae86f.png)

## Card

https://trello.com/c/HUgakJF1/8-borrar-generate-api-mock
