### PR TITLE
[React-Native] Adds a mini script that fixes xcode 10 interaction

### DIFF
--- a/react/react-native/docs/kickoff/README.md
+++ b/react/react-native/docs/kickoff/README.md
@@ -17,6 +17,13 @@ Before starting read this [Convention guide](../../../mobile/docs/naming/README.
 bash <(curl -s https://raw.githubusercontent.com/Wolox/wolmo-bootstrap-react-native/master/run.sh)
 ```
 
+1a. If the app have `double-conversion` or `fishhook` related errors, try running:  
+```
+cd node_modules/react-native/scripts && ./ios-install-third-party.sh && cd ../../../
+cd node_modules/react-native/third-party/glog-0.3.*/ && ../../scripts/ios-configure-glog.sh && cd ../../../../
+cp ios/build/Build/Products/Debug-iphonesimulator/libfishhook.a node_modules/react-native/Libraries/WebSocket/
+```
+
 2. Create app in Apple Developer Portal and iTunes Connect
 ```bash
 fastlane produce


### PR DESCRIPTION
## Summary

Adds a mini script that fixes xcode 10 interaction:
Usually, on first run of a project (after `npm install`) while using xcode 10, build may not succeed.

Related issues:
https://github.com/facebook/react-native/issues/19569
https://github.com/facebook/react-native/issues/21168

