### PR TITLE
[Java] Spring guides, troubleshooting, init Java tag 

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ If you need to add a new technology, follow the [Tech Kickoff Guide](./templates
      *  Android
      *  iOS
      *  Net Core
+     *  Java
      *  Infrastructure
      *  Git
      *  Wolox

--- a/java/docs/spring-reference-guide/annotation-glossary.md
+++ b/java/docs/spring-reference-guide/annotation-glossary.md
@@ -1,0 +1,75 @@
+# Spring reference
+
+## Annotations
+
+Annotations are tags that are used as indicators or instructions for the compiler. In this section you will find a list of the most used spring annotations and brief descriptions for each of them. 
+
+### Generic annotations 
+
+#### `@Autowired`
+It declares an attribute, constructor, setter or configuration method that generates automatically (one that doesn't need to be instantiated). 
+
+#### `@Component`
+Generic for any Spring component (controller, repository, etc.). It needs to be applied to classes that will be autowired. 
+
+#### `@Controller`
+It identifies an MVC controller. 
+
+#### `@Qualifier`
+It's used along with the `@Autowired` annotation in order to guide the autoconfiguration based on parameters other than the type (e.g.: name). 
+
+#### `@Repository`
+It identifies an MVC repository.  
+
+#### `@RequestMapping`
+It maps a URL or HTTP method to a method or controller. 
+
+#### `@RequestParam`
+It binds the parameter of a request to a method parameter. 
+
+#### `@Service`
+It identifies a service. 
+
+#### `@Value`
+It injects a value into an attribute. Said value can be set in the `application.properties` file. 
+
+### Test annotations 
+
+#### `@BootstrapWith`
+It is used to configure how the TestContext framework boots. 
+
+#### `@ContextConfiguration`
+It defines a metadata (class-level) that determines how an ApplicationContext is loaded and configured for integration tests. It declares the context and placement of application resources (.xml files, Groovy classes, @Configuration annotated classes). 
+
+#### `@TestPropertySource`
+It is used at class-level to configure the route where the property files will be placed. 
+
+#### `@WebAppConfiguration`
+It is used at class-level to declare that the ApplicationContext is a WebApplicationContext. 
+
+### Persistency annotations 
+
+#### `@Column`
+It identifies an attribute as a column of said table. 
+
+#### `@Entity` 
+It defines a class that can be mapped to a table. 
+
+#### `@GeneratedValue`
+It is used along with the `@Id` annotation in order to specify the generation strategy of the id. 
+
+#### `@Id` 
+It indicates that an attribute is a Primary Key in said table. 
+
+#### `@JoinTable`, `@JoinColumn` 
+They are used to indicate the relationship between tables of different entities (it specifies which attribute they have in common). 
+
+#### `@ManyToMany`, `@OneToOne`, `@OneToMany`, `@ManyToOne` 
+They are used to indicate the quantity relationship between different entities. 
+
+--------------- 
+For more information on this subject, please visit the following resources: 
+
+
+* [Test annotations](https://docs.spring.io/spring/docs/current/spring-framework-reference/testing.html#integration-testing-annotations-spring)  
+* Annotations in general: [1](https://www.baeldung.com/spring-core-annotations), [2](https://dzone.com/articles/a-guide-to-spring-framework-annotations) 

--- a/java/docs/spring-reference-guide/troubleshooting.md
+++ b/java/docs/spring-reference-guide/troubleshooting.md
@@ -1,0 +1,37 @@
+# Spring reference
+
+## Troubleshooting
+
+In this section you will find a list of some common issues that can occur during development, along with possible ways to fix them. 
+
+#### `Failed to load application context`
+Possible solutions: 
+* Remove @Repository` annotations. 
+* Add this annotation in the testcase: `@AutoconfigureTestDatabase(replace = NONE)`
+* Check inner exceptions for clear problems that could be causing the issue.
+* Verify that the configuration class is properly defined. 
+* Add the `@Component` annotation in classes that will be Autowired.
+
+#### `401 / 403 unauthorized error`
+Possible solutions: 
+* Add `@WebMvcTest(secure = false)` in the test annotation. This will isolate the test, focusing on the functionality rather than the security layer. 
+* Add `.with(csrf())` in the methods that perform an HTTP request on the mockMvc (use the following library: `org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf)`). 
+* Add `.with(testUser())` in methods that perform an HTTP request on the mockMvc.  
+
+#### `Found multiple declarations of @BootstrapWith`
+Possible solutions: 
+* Make sure that there is one and only one annotation related to test boot. For example, `@RunWith(SpringRunner.class)` and `@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)` cannot be used simultaneously. 
+
+#### `At least one JPA metamodel must be present!` or `No bean named ‘entityManagerFactory’ available`
+Possible solutions: 
+* Make sure that the annotations `@EntityScan` and `@EnableJpaRepositories` haven't been used. 
+
+#### `Tests are not injected` 
+Possible solutions: 
+* Make sure that you're not using the Jupiter junit dependency, but that of springboot: `org.springframework.boot:spring-boot-starter-test`. 
+
+#### `NullpointerException when trying to use @Autowired`
+Possible solutions: 
+* Make sure you haven't manually instantiated the class you're trying to autowire. 
+* Make sure you've properly set the annotations `@Component`, `@Service`, `@Repository`, `@Controller` in the class that you're trying to autowire. 
+

--- a/java/docs/standards/java-style-guide.md
+++ b/java/docs/standards/java-style-guide.md
@@ -1,0 +1,57 @@
+# Standards 
+
+## Code style 
+
+#### IntelliJ Save Action Plugin
+We use the IntelliJ Save Action plugin to format the code on save, organize imports
+and methods.
+
+Follow these instructions to install it:
+1. Go to File > Settings > Plugins.
+2. Search for plugin “Save Actions” and click install.
+3. Search for “Save Actions” in the panel Settings and configure it as follows:
+
+![save actions](https://image.ibb.co/jxeOCf/save-actions.png)
+
+
+https://plugins.jetbrains.com/plugin/7642-save-actions
+
+#### Google xml Code Style
+
+We follow the Google Java code style and the best way to adhere it is
+using the IntelliJ automatic formatter.
+To accomplish this we need to configure the code style in IntelliJ using
+the google xml code style configuration file.
+
+You can find the xml file here
+https://github.com/google/styleguide/blob/gh-pages/intellij-java-google-style.xml
+
+And follow these instructions to import it:
+1. Download the .xml.
+2. Go to File > Settings > Editor > Code style.
+3. Import the .xml:
+4. Go to the Java section and change the indent size to 4.
+
+![code style](https://image.ibb.co/jRB9k0/code-style.png)
+
+
+#### SonarLint installation in IntelliJ
+A linter is a tool that can be used to analyze source code and flag errors, bugs, style errors, etc.
+SonarLint is a plugin for IntelliJ that exists with this purpose. In order to configure it, follow
+these instructions:
+1. Go to File > Settings > Plugins.
+2. Search for plugin "Sonarlint" and select "Browse repositories". The following screen will appear:
+
+![sonarlint plugin](https://image.ibb.co/gvDxsf/sonarlint1.png)
+
+
+The tool will be automatically configured in IntelliJ. When writing code, some problematic sections
+will be highlighted and the tool will provide suggestions to fix the potential bugs.
+
+![sonarlint highlight](https://image.ibb.co/bFriXf/sonarlint2.png)
+
+
+The tool can be customized by changing highlight colors if desired. To do this go to
+File > Settings SonarLint:
+
+![sonarlint colors](https://image.ibb.co/b5O8yL/sonarlint3.png)

--- a/java/docs/standards/spring-security.md
+++ b/java/docs/standards/spring-security.md
@@ -1,0 +1,29 @@
+# Standards 
+
+## Spring security 
+
+CSRF (Cross Site Request Forgery) is a kind of attack that forces the user to execute unwanted actions through request methods (GET, POST, PUT, etc.) 
+
+CSRF protection is enabled by default in Java configuration, server side. Some tips to follow:  
+* Make sure to use the proper HTTP methods for any state modification (PATCH, POST, PUT and DELETE - never GET). 
+* Activate CSRF on the client side, e.g.:
+  * Using extra parameters in forms:  
+  
+      `<input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>`
+  * CSRF tokens can be sent as headers using JSON. First, they are included in the page: 
+  
+        <meta name="_csrf" content="${_csrf.token}"/>
+        
+        <meta name="_csrf_header" content="${_csrf.headerName}"/>
+    
+     and then the header is constructed: 
+  
+        var token = $("meta[name='_csrf']").attr("content");
+        
+        var header = $("meta[name='_csrf_header']").attr("content");
+        
+        $(document).ajaxSend(function(e, xhr, options) {
+          xhr.setRequestHeader(header, token);
+         });
+   
+* In order to write tests with enabled CSRF protection and validate that the status is 403 when trying to perform protected operations, you can use `.with(csrf()` in the method. 


### PR DESCRIPTION
## Summary
The following additions have been made: 
* `[Java]` tag in techguides README, 'Contributing' section 
* Spring annotation glossary 
* Java Spring troubleshooting 
* Spring security overview 
* Style guide overview (Google Code style, Save Actions plugin) 
* SonarLint installation and overview