### PR TITLE
[AngularJS]Change angular bootstrap guide link

### DIFF
--- a/frontend/angular-js/README.md
+++ b/frontend/angular-js/README.md
@@ -10,7 +10,7 @@
 
 ## Project Bootstrapper
 
-At [Wolox](http://wolox.com.ar), we have developed the [AngularJS Bootstrap](http://github.com/wolox/frontend-bootstrap) (use `angular` branch) to create our AngularJS projects. You'll find a detailed guide to start with your project in its README.
+At [Wolox](http://wolox.com.ar), we have developed the [AngularJS Bootstrap](https://github.com/wolox/angularjs-bootstrap) to create our AngularJS projects. You'll find a detailed guide to start with your project in its README.
 
 ## Style Guide
 


### PR DESCRIPTION
## Summary

I change [current angular bootstrap link](https://github.com/wolox/frontend-bootstrap) to his own [new link](https://github.com/wolox/angularjs-bootstrap)


## Trellocard

https://trello.com/c/RCLA0PvO/28-cambiar-bootstrap-de-angularjs-para-que-referencie-al-nuevo
