### PR TITLE
fix link to vue-style-guide

### DIFF
--- a/frontend/vue/README.md
+++ b/frontend/vue/README.md
@@ -15,7 +15,7 @@ You'll find a detailed guide to start your project [here](./docs/kickoff.md).
 ## Style Guide
 
 We use our own Style Guide that has been strongly influenced by the [Vue Official Style Guide](https://vuejs.org/v2/style-guide/).
- - [Wolox Vue Style Guide](https://github.com/Wolox/tech-guides/tree/master/frontend/vue/style-guide.mb)
+ - [Wolox Vue Style Guide](https://github.com/Wolox/tech-guides/tree/master/frontend/vue/style-guide.md)
 
 
 ## Internal Libraries


### PR DESCRIPTION
## Summary
Update extension to the link of Wolox Vue Style Guide. Drom **.mb** to **.md**. 

Now the link is broken, you can see it in the [Wolox/Vue tech guides](https://github.com/Wolox/tech-guides/tree/master/frontend/vue)

